### PR TITLE
chore: update dependencies to latest stable versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm") version "2.3.20"
-    id("com.gradleup.shadow") version "8.3.6"
+    id("com.gradleup.shadow") version "9.4.0"
     jacoco
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/koy-playground/build.gradle.kts
+++ b/koy-playground/build.gradle.kts
@@ -20,8 +20,8 @@ dependencies {
     implementation("io.ktor:ktor-server-content-negotiation:3.4.2")
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.4.2")
     implementation("io.ktor:ktor-server-cors:3.4.2")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
-    implementation("ch.qos.logback:logback-classic:1.5.18")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    implementation("ch.qos.logback:logback-classic:1.5.32")
 
     testImplementation(kotlin("test"))
     testImplementation("io.ktor:ktor-server-test-host:3.4.2")
@@ -29,6 +29,11 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    dependsOn(":shadowJar")
+}
+
+tasks.named("startScripts") {
+    dependsOn(":shadowJar")
 }
 
 application {


### PR DESCRIPTION
## Summary

- Gradle wrapper: 8.12 → 9.4.1
- `com.gradleup.shadow`: 8.3.6 → 9.4.0
- `kotlinx-serialization-json`: 1.8.1 → 1.10.0
- `logback-classic`: 1.5.18 → 1.5.32
- Gradle 9.x で厳格化されたタスク依存関係チェックに対応するため、`koy-playground/build.gradle.kts` の `tasks.test` と `startScripts` に `dependsOn(":shadowJar")` を追加

## Test plan

- [x] `./gradlew clean build` が成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)