### PR TITLE
docs: add README for koy-playground

### DIFF
--- a/koy-playground/README.md
+++ b/koy-playground/README.md
@@ -1,0 +1,57 @@
+# Koy Playground
+
+A web-based execution environment for the Koy programming language.
+Write and run Koy code directly in your browser.
+
+## Prerequisites
+
+| Tool | Version |
+|---|---|
+| JDK | 21 or later |
+| Node.js | LTS (managed via mise) |
+| pnpm | 10.33.0 (managed via mise) |
+
+Install [mise](https://github.com/jdx/mise):
+
+```bash
+curl https://mise.run | sh
+```
+
+Then set up Node.js and pnpm:
+
+```bash
+mise install
+```
+
+## Build
+
+Build the frontend and bundle it into the backend's static resources:
+
+```bash
+cd frontend
+pnpm install
+pnpm build
+```
+
+Then build the backend (from the repository root):
+
+```bash
+./gradlew :koy-playground:build
+```
+
+## Run
+
+Start the server from the repository root:
+
+```bash
+./gradlew :koy-playground:run
+```
+
+The server starts on `http://localhost:8080`.
+
+## Usage
+
+1. Open `http://localhost:8080` in your browser.
+2. Write Koy code in the editor on the left.
+3. Click **▶ Run** to execute the code.
+4. The output appears in the right pane. If an error occurs, the stack trace is shown in red.


### PR DESCRIPTION
## Summary

- `koy-playground/README.md` を新規作成
- Prerequisites（JDK・mise のインストール・Node.js/pnpm のセットアップ）、Build、Run、Usage の4セクションを記載

## Test plan

- [ ] README の手順に沿って `mise install` → `pnpm build` → `./gradlew :koy-playground:run` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)