### PR TITLE
docs: add ADRs for record/trait and error handling

### DIFF
--- a/docs/adr/0002-record-and-trait.md
+++ b/docs/adr/0002-record-and-trait.md
@@ -1,0 +1,200 @@
+# ADR-0002: record と trait による値と振る舞いの設計
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+Koy 言語を比較的サイズのあるプロダクトにも対応できる言語へ進化させるにあたり、値と振る舞いをバンドルする機構が必要になった。
+
+Koy の言語思想は以下の通り。
+
+- **式ベース**: すべての構文要素が値を返す
+- **イミュータブルファースト**: `val` がデフォルト、`mutable val` でオプトイン
+- **インタプリタ**: ツリーウォーキング方式、GC に依存
+
+この思想と整合する形で、データ構造の定義とポリモーフィズムの仕組みを設計する必要がある。
+
+### 検討した振る舞いバンドルの方式
+
+| 方式 | 代表的な言語 | 概要 |
+|---|---|---|
+| クラス継承 | Java, Python, C# | クラスに値と振る舞いを持たせ、継承で差分を表現する |
+| Struct + Trait | Rust, Swift | データ定義と振る舞い契約を分離し、`impl` ブロックで後付け結合する |
+| Typeclass | Haskell, Scala 3 | 型に対する振る舞いの証拠（witness）を文脈ごとに渡す |
+| ADT + モジュール | F#, OCaml, Elm | 代数的データ型を定義し、モジュール内の関数群で操作する |
+
+## 決定
+
+**record** と **trait** を言語の中核機構として導入する。
+
+### record
+
+`record` は値の集合を主とし、振る舞いを付随させる構造体を定義する予約語である。
+
+```koy
+record Point with Describable {
+  x: Int,
+  y: Int,
+
+  fn distance(self, other: Point): Int {
+    val dx = self.x - other.x;
+    val dy = self.y - other.y;
+    dx * dx + dy * dy;
+  }
+
+  fn describe(self): String {
+    "(" + self.x + ", " + self.y + ")";
+  }
+}
+```
+
+record の性質:
+
+- **予約語**であり、record のインスタンスを生成する
+- **式**である。変数に束縛でき、関数の戻り値やコレクションの要素として使える
+- **イミュータブル**がデフォルト
+- すべての record は **Record trait** を暗黙的に満たす（Record trait の具体的な内容は今後詳細化する）
+
+#### 全リテラルが record である
+
+Ruby の「すべてが Object」と同じ考え方で、Koy のすべてのリテラルは record である。
+
+```koy
+42                     // Int record
+"hello"                // String record
+true                   // Bool record
+[1, 2, 3]             // Array record
+%{ "a", "b" }         // Set record
+{ x: 1, y: 2 }       // Object record
+|x| { x + 1; }       // Function record
+nil                    // Nil record
+Point { x: 1, y: 2 } // ユーザー定義 record
+```
+
+これにより以下が実現される。
+
+- 言語の値に関するルールが「すべて record である」の一つで済む
+- プリミティブとオブジェクトの挙動差異がない（Java の `int` vs `Integer` 問題が存在しない）
+- 組み込み型とユーザー定義型を同じ仕組みで扱える
+
+#### record の命名根拠
+
+`struct`、`data`、`type`、`model` 等の候補を検討した。
+
+| 候補 | 不採用の理由 |
+|---|---|
+| `struct` | C/Go の低レベルなメモリレイアウトの印象がある。インタプリタ言語とのミスマッチ |
+| `data` | 意味は合うが、変数名として `data` を使いたい場面が多く予約語にすると実用上の衝突がある |
+| `type` | 型注釈（`x: Int`）の文脈と紛らわしい |
+| `model` | 意味が曖昧 |
+
+`record` は「値を記録したもの」という原義がイミュータブルの思想と合致し、プログラマに広く馴染みがあり、変数名との衝突が起きにくい。
+
+### trait
+
+`trait` は振る舞いの契約を定義する予約語である。record は `with` キーワードで trait を取り込み、一つのブレース内にデータ・メソッド・trait 実装をすべて記述する。
+
+```koy
+trait Describable {
+  fn describe(self): String;
+}
+
+trait Eq {
+  fn eq(self, other): Bool;
+}
+
+record Point with Describable, Eq {
+  x: Int,
+  y: Int,
+
+  fn describe(self): String {
+    "(" + self.x + ", " + self.y + ")";
+  }
+
+  fn eq(self, other): Bool {
+    self.x == other.x and self.y == other.y;
+  }
+}
+```
+
+trait の性質:
+
+- **振る舞いの契約**を定義する。record が `with` で取り込むことで「この record はこの特性を満たす」と宣言する
+- **デフォルト実装**を持てる。trait 内に関数本体を書くと、record 側で実装を省略できる
+- **ポリモーフィズム**を実現する。異なる record が同じ trait を満たすことで、共通のインターフェースで扱える
+
+```koy
+trait Printable {
+  fn to_string(self): String;
+
+  // デフォルト実装：to_string さえ実装すれば print はタダで使える
+  fn print(self) {
+    println(self.to_string());
+  }
+}
+```
+
+#### with による一体宣言
+
+Rust の `impl Trait for Type` のように振る舞いの実装を型定義の外に分離する方式は採用しない。record 宣言の一つのブレース内に値・振る舞い・trait 実装がすべてまとまることで、その record の全体像を一箇所で把握できる。
+
+```koy
+// Koy: 一箇所にすべてまとまる
+record Point with Describable, Eq {
+  x: Int,           // データ
+  y: Int,
+  fn distance ...   // 自前メソッド
+  fn describe ...   // trait 実装
+  fn eq ...         // trait 実装
+}
+
+// Rust: impl が分散する（不採用）
+// struct Point { x: i32, y: i32 }
+// impl Describable for Point { ... }
+// impl Eq for Point { ... }
+```
+
+### sealed
+
+`sealed` は record のバリアント集合を定義する予約語である。取りうる値のバリエーションが有限であることを型として表現する。
+
+```koy
+sealed Shape with Describable {
+  Circle { radius: Int },
+  Rect { width: Int, height: Int },
+
+  fn area(self): Int {
+    match(self) {
+      Circle(r) => r * r * 3;
+      Rect(w, h) => w * h;
+    };
+  }
+
+  fn describe(self): String {
+    match(self) {
+      Circle(r) => "circle r=" + r;
+      Rect(w, h) => w + "x" + h;
+    };
+  }
+}
+```
+
+sealed は match 式と連携し、全パターンの網羅性を検査できる。
+
+## 採用しなかった案
+
+| 案 | 不採用の理由 |
+|---|---|
+| クラス継承 | 可変状態を前提とし、式ベース・イミュータブルの思想と合わない。fragile base class 問題やダイヤモンド継承の問題を持ち込む |
+| `impl` ブロックの分離（Rust 方式） | 振る舞いが型定義の外に分散し、一箇所で全体像を把握できない |
+| Typeclass | 概念のハードルが高く、インタプリタ実装が複雑になる |
+| ADT + モジュールのみ（trait なし） | ポリモーフィズムが弱く、大規模プロダクトでのインターフェース契約が不足する |
+
+## 結果
+
+- `record` がデータ構造の唯一の定義手段となり、全リテラルも record として統一される
+- `trait` + `with` により継承なしでポリモーフィズムを実現し、一つのブレースで値・振る舞い・特性を一覧できる
+- `sealed` により有限のバリアント表現と match 式による網羅的なディスパッチが可能になる
+- これらの組み合わせで、式ベース・イミュータブルの思想を保ちながら、大規模プロダクトにも対応できる構造化の仕組みを提供する

--- a/docs/adr/0003-error-handling.md
+++ b/docs/adr/0003-error-handling.md
@@ -1,0 +1,124 @@
+# ADR-0003: エラーハンドリングの設計
+
+## ステータス
+
+Draft
+
+## コンテキスト
+
+Koy 言語にエラーハンドリングの仕組みを導入するにあたり、言語思想（式ベース・イミュータブル）と実用性（書きやすさ・レイヤーをまたぐ伝播）を両立する設計が求められる。
+
+### 検討した方式
+
+| 方式 | 代表的な言語 | 概要 |
+|---|---|---|
+| Result 型のみ | Rust, Elm | 失敗を値として表現し、match で処理する。堅牢だが冗長になりがち |
+| 例外スローのみ | Ruby, Python | throw/raise で制御フローを中断する。書きやすいが関数シグネチャに失敗が見えない |
+| 検査例外 | Java | シグネチャに `throws` を宣言し、呼び出し側に処理を強制する。形骸化した歴史がある |
+| 順序対 (value, error) | Go | 関数が値とエラーのタプルを返す。チェック忘れが頻発する |
+
+## 決定の方向性
+
+**二層構造**を採用する方向で検討を進める。
+
+### 第一層: Result 型（業務エラー）
+
+予期される失敗を sealed 型の値として表現する。関数シグネチャに `Result` が現れることで、呼び出し側が失敗を認識できる。
+
+```koy
+sealed Result {
+  Ok { value },
+  Err { message: String },
+}
+
+fn find_user(id: Int): Result {
+  if (id <= 0) {
+    Err("invalid id");
+  } else {
+    Ok(db.lookup(id));
+  };
+}
+```
+
+冗長さを緩和するシンタックスシュガーを併せて導入する。
+
+#### `or` 演算子
+
+Result から値を取り出し、Err の場合はフォールバック値を返す。
+
+```koy
+val name = find_user(42) |> map(|u| { u.name; }) |> or("anonymous");
+```
+
+#### `?` 演算子
+
+Result を返す関数内で、Err をそのまま呼び出し元に伝播する。レイヤーをまたぐ業務エラーの伝播はこれで解決する。
+
+```koy
+fn get_user_profile(id: Int): Result {
+  val user = find_user(id)?;          // Err なら即 return Err
+  val profile = fetch_profile(user)?; // 同上
+  Ok(profile);
+}
+```
+
+### 第二層: 例外（システムエラー）
+
+プログラマのミスやシステムの異常事態は throw + try-catch で処理する。try-catch は式であり値を返す。
+
+```koy
+// throw
+fn get(arr, index) {
+  if (index < 0) {
+    throw "index out of bounds";
+  };
+  arr->index;
+}
+
+// try-catch（式）
+val item = try { get(arr, 99); } catch(e) { nil; };
+```
+
+### 二層構造の判断基準
+
+| 層 | 手段 | 対象 | シグネチャ |
+|---|---|---|---|
+| 業務エラー | Result + `?` + `or` | ユーザー検索失敗、バリデーション不正等 | 戻り値が `Result` → 失敗しうることが見える |
+| システムエラー | throw + try-catch | ゼロ除算、範囲外アクセス、バグ | 戻り値に現れない → 正常に使えば起きない前提 |
+
+### sealed によるエラー種別の型定義
+
+業務エラーの種類が多い場合は sealed でエラー型を定義し、match で網羅的にハンドリングする。
+
+```koy
+sealed AppError {
+  NotFound { resource: String, id: Int },
+  Validation { field: String, message: String },
+  Unauthorized { reason: String },
+}
+
+fn handle_request(id: Int) {
+  match(get_user_profile(id)) {
+    Ok(res) => send(200, res);
+    Err(NotFound(r, id)) => send(404, r + " not found");
+    Err(Validation(f, m)) => send(400, f + ": " + m);
+    Err(Unauthorized(r)) => send(401, r);
+  };
+}
+```
+
+## 未決事項
+
+- Result 型を言語組み込みの sealed として提供するか、ユーザー定義に委ねるか
+- `?` 演算子の詳細な構文規則（連鎖、ネスト時の挙動）
+- try-catch の構文詳細（catch の引数の型、複数 catch 節の要否）
+- Result に対する標準的な高階関数（`map`, `flatmap`, `recover` 等）の仕様
+
+## 採用しなかった案
+
+| 案 | 不採用の理由 |
+|---|---|
+| 例外のみ | 関数シグネチャから失敗が見えない。呼び出し側が例外の存在を知るにはドキュメントかソースを読む必要がある |
+| Result のみ（シュガーなし） | 堅牢だが match のネストが深くなり、日常的なコードが冗長になる |
+| 検査例外 | Java での形骸化の歴史を踏まえ、不採用 |
+| 順序対 (value, error) | Go スタイル。エラーチェック忘れが頻発し、自然な書き味を追究する Koy の方向性と合わない |

--- a/docs/ideas/result-and-error-handling.md
+++ b/docs/ideas/result-and-error-handling.md
@@ -1,0 +1,140 @@
+# 構想: Result / or / try によるエラーハンドリング
+
+## 概要
+
+Koy のエラーハンドリングは二層構造を取る。
+
+- **業務エラー**: Result 型（sealed）+ `?` 演算子 + `or` 演算子
+- **システムエラー**: throw + try-catch（式）
+
+## Result 型
+
+sealed として定義される。言語組み込みか、ユーザー定義かは未決。
+
+```koy
+sealed Result {
+  Ok { value },
+  Err { message: String },
+}
+```
+
+### 基本的な使い方
+
+```koy
+fn find_user(id: Int): Result {
+  if (id <= 0) {
+    Err("invalid id");
+  } else {
+    Ok(db.lookup(id));
+  };
+}
+```
+
+戻り値が `Result` であること自体が「この関数は失敗しうる」という契約になる。
+
+## or 演算子
+
+Result から値を取り出し、Err の場合はフォールバック値を返す。Kotlin の `?:` (elvis) に相当するが、英語として自然に読める。
+
+```koy
+val user = find_user(42) or default_user;
+val name = find_user(42) |> map(|u| { u.name; }) |> or("anonymous");
+```
+
+## ? 演算子
+
+Result を返す関数の中で、Err をそのまま呼び出し元に伝播する。レイヤーをまたぐ業務エラーの伝播を簡潔に書ける。
+
+```koy
+fn get_user_profile(id: Int): Result {
+  val user = find_user(id)?;          // Err なら即 return Err
+  val profile = fetch_profile(user)?; // 同上
+  Ok(profile);
+}
+```
+
+`?` がない場合の等価コード:
+
+```koy
+fn get_user_profile(id: Int): Result {
+  match(find_user(id)) {
+    Ok(user) => match(fetch_profile(user)) {
+      Ok(profile) => Ok(profile);
+      Err(e) => Err(e);
+    };
+    Err(e) => Err(e);
+  };
+}
+```
+
+## throw / try-catch
+
+システムの異常事態（バグ、範囲外アクセス等）を扱う。try-catch は式であり、値を返す。
+
+```koy
+// throw
+fn get(arr, index) {
+  if (index < 0) {
+    throw "index out of bounds";
+  };
+  arr->index;
+}
+
+// try-catch は式
+val item = try { get(arr, 99); } catch(e) { nil; };
+```
+
+## パイプラインとの連携
+
+Result はパイプライン演算子と組み合わせて使うことを想定する。
+
+```koy
+val name = find_user(42)
+  |> map(|u| { u.name; })
+  |> or("anonymous");
+
+val result = fetch_data(url)
+  |> flatmap(|d| { parse(d); })
+  |> flatmap(|p| { validate(p); })
+  |> map(|v| { format(v); })
+  |> or(default_response);
+```
+
+## sealed によるエラー型の定義
+
+業務エラーの種類が多い場合は sealed でドメイン固有のエラー型を定義する。
+
+```koy
+sealed AppError {
+  NotFound { resource: String, id: Int },
+  Validation { field: String, message: String },
+  Unauthorized { reason: String },
+}
+
+// 途中のレイヤーは ? で伝播するだけ
+fn get_user_profile(id: Int): Result {
+  val user = find_user(id)?;
+  val profile = fetch_profile(user)?;
+  Ok(profile);
+}
+
+// 最終的にハンドリングする層で match
+fn handle_request(id: Int) {
+  match(get_user_profile(id)) {
+    Ok(res) => send(200, res);
+    Err(NotFound(r, id)) => send(404, r + " not found");
+    Err(Validation(f, m)) => send(400, f + ": " + m);
+    Err(Unauthorized(r)) => send(401, r);
+  };
+}
+```
+
+## 未決事項
+
+- Result を言語組み込みの sealed として提供するか、標準ライブラリとして提供するか、ユーザー定義に委ねるか
+- Result の型パラメータ: `Result<T, E>` のようにジェネリクスを持たせるか、動的型のまま `Ok { value }` とするか
+- `?` 演算子のスコープ: Result を返す関数の中でのみ使えるのか、トップレベルでも使えるのか
+- `or` の評価戦略: `or` の右辺は遅延評価か即時評価か（`or { expensive_fallback(); }` のような構文が要るか）
+- try-catch の catch 節: エラーの型によるフィルタリング（複数 catch 節）を持たせるか
+- Result に対する標準的な高階関数の一覧と仕様（`map`, `flatmap`, `recover`, `onSuccess`, `onFailure` 等）
+- match 式の網羅性検査: sealed のバリアントを全て網羅しているかインタプリタがチェックするか


### PR DESCRIPTION
## Summary
- ADR-0002 (Accepted): record + trait + sealed による値と振る舞いの設計を決定
- ADR-0003 (Draft): Result/or/try によるエラーハンドリングの二層構造を起案
- `docs/ideas/` に Result 型・パイプライン連携の構想メモを追加

## Test plan
- [ ] ADR の内容がこれまでの議論と整合しているか確認
- [ ] 未決事項の一覧に漏れがないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)